### PR TITLE
Fix problems with monster Spawned from creature lab customizations

### DIFF
--- a/chimeraColosseumProject/Assets/Scenes/BattleScene.unity
+++ b/chimeraColosseumProject/Assets/Scenes/BattleScene.unity
@@ -365,7 +365,7 @@ MonoBehaviour:
   spawnCooldown: 0.5
   spawnContinuously: 0
   spawnWithAI: 1
-  totalMonstersToSpawn: 2
+  totalMonstersToSpawn: 1
   allCores:
   - {fileID: 8417863888733090835, guid: fbe678cf7877b9e458312b842bf22692, type: 3}
   - {fileID: 3799558491816368408, guid: 2d46a6eeda86838459efb0a2c4d85e1d, type: 3}

--- a/chimeraColosseumProject/Assets/Scenes/CreatureLab.unity
+++ b/chimeraColosseumProject/Assets/Scenes/CreatureLab.unity
@@ -157,7 +157,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 3.1401076}
+  m_AnchoredPosition: {x: 0, y: 3.1400115}
   m_SizeDelta: {x: 0, y: 636.14}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &70736762
@@ -1171,8 +1171,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 532477522}
   m_HandleRect: {fileID: 532477521}
   m_Direction: 2
-  m_Value: -0.000019437857
-  m_Size: 0.9690951
+  m_Value: 0
+  m_Size: 0.9934858
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -2944,7 +2944,7 @@ MonoBehaviour:
   spawnCooldown: 111111
   spawnContinuously: 0
   spawnWithAI: 0
-  currentSpawnNumber: 0
+  totalMonstersToSpawn: 0
   allCores:
   - {fileID: -4955358104429177216, guid: 31e83ef86983de941b96414689a9bb2e, type: 3}
   allHeads:

--- a/chimeraColosseumProject/Assets/Scripts/BattleScene/MonsterAI.cs
+++ b/chimeraColosseumProject/Assets/Scripts/BattleScene/MonsterAI.cs
@@ -50,13 +50,14 @@ public class MonsterAI : MonoBehaviour
     void Update()
     {
         // ONLY do movement and attack behavior if there is a target in the scene 
-        if (targetMonster != null)
+        // And if health is a non zero value
+        if (targetMonster != null && thisMonster.getHP() > 0)
         {
             // Moves the monster towards the enemy monster by its speed
             moveScript.Move(targetTransform, thisMonster.getSpeed());
             // Checks if the monster is in range and off attack cooldown
             // Then, gives the enemy monster knockback and makes it lose health
-            if (attackScript.CanAttack(targetTransform))
+            if (attackScript.CanAttack(targetTransform) && targetMonster.GetComponent<MonsterMove>() != null)
             {
                 targetMonster.GetComponent<MonsterMove>().Knockback(thisMonster.getDamage());
                 targetMonster.takeDamage(thisMonster.getDamage());

--- a/chimeraColosseumProject/Assets/Scripts/GameManager.cs
+++ b/chimeraColosseumProject/Assets/Scripts/GameManager.cs
@@ -27,11 +27,16 @@ public class GameManager : MonoBehaviour
     public void SpawnCreature()
     {
         MonsterSpawner monsterSpawner = new MonsterSpawner();
-        monsterSpawner.SetArm(arm.GetComponent<Part>());
-        monsterSpawner.SetLeg(leg.GetComponent<Part>());
-        monsterSpawner.SetHead(head.GetComponent<Part>());
-        monsterSpawner.SetCore(torso.GetComponent<Part>());
+        monsterSpawner.spawnWithAI = true;
+        // This isn't clean code in the slightest, but to prevent having to change what parts 
+        // the GameManager is being given by the creature lab, grabbing the object's PartHandler script 
+        // can get you a reference to the proper part object
+        monsterSpawner.SetArm(arm.GetComponent<PartHandler>().part.GetComponent<Part>());
+        monsterSpawner.SetLeg(leg.GetComponent<PartHandler>().part.GetComponent<Part>());
+        monsterSpawner.SetHead(head.GetComponent<PartHandler>().part.GetComponent<Part>());
+        monsterSpawner.SetCore(torso.GetComponent<PartHandler>().part.GetComponent<Part>());
         monsterSpawner.SpawnRandomMonster(new Vector2(-3, 0));
+ 
     }
 
 }

--- a/chimeraColosseumProject/Assets/Scripts/GameManager.cs
+++ b/chimeraColosseumProject/Assets/Scripts/GameManager.cs
@@ -31,7 +31,7 @@ public class GameManager : MonoBehaviour
         monsterSpawner.SetLeg(leg.GetComponent<Part>());
         monsterSpawner.SetHead(head.GetComponent<Part>());
         monsterSpawner.SetCore(torso.GetComponent<Part>());
-        monsterSpawner.SpawnLabMonster();
+        monsterSpawner.SpawnRandomMonster(new Vector2(-3, 0));
     }
 
 }

--- a/chimeraColosseumProject/Assets/Scripts/Monster/Monster.cs
+++ b/chimeraColosseumProject/Assets/Scripts/Monster/Monster.cs
@@ -8,7 +8,10 @@ public class Monster : MonoBehaviour
 
     private Core corePart;
 
+    // Need these to be visible for testing for now
+    [SerializeField]
     private float speed = 0;
+    [SerializeField]
     private float damage = 0;
     public float health = 100f;
 
@@ -24,6 +27,8 @@ public class Monster : MonoBehaviour
     void Start()
     {
         corePart = GetComponentInChildren<Core>();
+        if(speed > 0 || damage > 0)
+            resetStats();
         if(corePart.transform.childCount > 0)
             SetStats();
     }
@@ -37,6 +42,13 @@ public class Monster : MonoBehaviour
     }
 
     // METHODS
+
+    public void resetStats()
+    {
+        // Needed to fix a bug related to the monster going from the lab scene to the battle scene 
+        speed = 0;
+        damage = 0;
+    }
 
     public void SetStats()
     {

--- a/chimeraColosseumProject/Assets/Scripts/Monster/MonsterSpawner.cs
+++ b/chimeraColosseumProject/Assets/Scripts/Monster/MonsterSpawner.cs
@@ -63,6 +63,9 @@ public class MonsterSpawner : MonoBehaviour
         {
             lastSpawnTime = Time.time;
             SpawnRandomMonster(this.transform.position);
+
+            // Iterate the spawn count so the next created monster has a different name.
+            currentSpawnNumber += 1;
         }
     }
 
@@ -121,8 +124,6 @@ public class MonsterSpawner : MonoBehaviour
             monster.AddComponent<MonsterAttack>();
         }
 
-        // Iterate the spawn count so the next created monster has a different name.
-        currentSpawnNumber += 1;
     }
 
     public void SpawnLabMonster() {

--- a/chimeraColosseumProject/Assets/Scripts/Monster/MonsterSpawner.cs
+++ b/chimeraColosseumProject/Assets/Scripts/Monster/MonsterSpawner.cs
@@ -168,6 +168,15 @@ public class MonsterSpawner : MonoBehaviour
             Instantiate(arm.GetComponent<PartHandler>().part, coreObj.transform.position + core.armJoints[i], Quaternion.identity, coreObj.transform);
         }
 
+        // Check if the monster to be spawned should have AI, and if so, add that component.
+        if (spawnWithAI)
+        {
+            // Spawn the monster with their AI component if allowed
+            monster.AddComponent<MonsterAI>();
+            monster.AddComponent<MonsterMove>();
+            monster.AddComponent<MonsterAttack>();
+        }
+
         monster.transform.localScale = new Vector3(10, 10, 1);
     }
 


### PR DESCRIPTION
The monster spawned into the battle scene based on creature lab customizations now is functional, being visible and having stats reflecting the parts it was customized to have. 